### PR TITLE
Release 0.3.0-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26011,7 +26011,7 @@
     },
     "packages/insomnia": {
       "name": "insomnium",
-      "version": "0.2.3-a",
+      "version": "0.3.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "@apideck/better-ajv-errors": "^0.3.6",
@@ -26172,7 +26172,7 @@
       }
     },
     "packages/insomnia-send-request": {
-      "version": "0.2.3-a",
+      "version": "0.3.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@getinsomnia/node-libcurl": "3.2.2",
@@ -26230,7 +26230,7 @@
       }
     },
     "packages/insomnia-smoke-test": {
-      "version": "0.2.3-a",
+      "version": "0.3.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "depd": "^1.1.2",
@@ -26306,7 +26306,7 @@
       }
     },
     "packages/insomnia-testing": {
-      "version": "0.2.3-a",
+      "version": "0.3.0-rc.1",
       "license": "Apache-2.0"
     },
     "packages/insomnia/node_modules/@apideck/better-ajv-errors": {

--- a/packages/insomnia-send-request/package.json
+++ b/packages/insomnia-send-request/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "insomnia-send-request",
   "license": "Apache-2.0",
-  "version": "0.2.3-a",
+  "version": "0.3.0-rc.1",
   "author": "Archy <archy@archgpt.dev>",
   "main": "dist/index.js",
   "types": "dist/send-request/index.d.ts",

--- a/packages/insomnia-smoke-test/package.json
+++ b/packages/insomnia-smoke-test/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/ArchGPT/insomnium/issues"
   },
-  "version": "0.2.3-a",
+  "version": "0.3.0-rc.1",
   "scripts": {
     "test:dev": "xvfb-maybe cross-env BUNDLE=dev playwright test",
     "test:build": "xvfb-maybe cross-env BUNDLE=build playwright test",

--- a/packages/insomnia-testing/package.json
+++ b/packages/insomnia-testing/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "insomnia-testing",
   "license": "Apache-2.0",
-  "version": "0.2.3-a",
+  "version": "0.3.0-rc.1",
   "author": "Archy <archy@archgpt.dev>",
   "repository": {
     "type": "git",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnium",
-  "version": "0.2.3-a",
+  "version": "0.3.0-rc.1",
   "productName": "Insomnium",
   "private": true,
   "description": "The Collaborative API Design Tool",


### PR DESCRIPTION
## Summary
- Bump app version to `0.3.0-rc.1` across all 4 workspace packages + lockfile
- Cuts a prerelease for end-to-end pipeline verification (release-on-publish + homebrew tap bump)

## Test plan
- [ ] CI green on this PR
- [ ] Merge + tag `0.3.0-rc.1`
- [ ] release-on-publish.yml builds macOS/Windows/Linux artifacts
- [ ] Artifacts attached to GitHub release
- [ ] homebrew.yml bumps yokomohoyo/homebrew-tap cask

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>