### PR TITLE
Pin @asyncapi/specs to 6.11.1 (Miasma RAT advisory)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26915,7 +26915,7 @@
     },
     "packages/insomnia": {
       "name": "insomnium",
-      "version": "0.3.0-rc.5",
+      "version": "0.3.0-rc.7",
       "license": "MIT",
       "dependencies": {
         "@apideck/better-ajv-errors": "^0.3.6",
@@ -27076,7 +27076,7 @@
       }
     },
     "packages/insomnia-send-request": {
-      "version": "0.3.0-rc.5",
+      "version": "0.3.0-rc.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@getinsomnia/node-libcurl": "3.2.2",
@@ -27118,7 +27118,7 @@
       }
     },
     "packages/insomnia-smoke-test": {
-      "version": "0.3.0-rc.5",
+      "version": "0.3.0-rc.7",
       "license": "Apache-2.0",
       "dependencies": {
         "depd": "^1.1.2",
@@ -27194,7 +27194,7 @@
       }
     },
     "packages/insomnia-testing": {
-      "version": "0.3.0-rc.5",
+      "version": "0.3.0-rc.7",
       "license": "Apache-2.0"
     },
     "packages/insomnia/node_modules/@apideck/better-ajv-errors": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "xml2js": "^0.5.0",
     "lodash": "^4.18.1",
     "serialize-javascript": "^7.0.5",
-    "form-data": "^4.0.6"
+    "form-data": "^4.0.6",
+    "@asyncapi/specs": "6.11.1"
   }
 }


### PR DESCRIPTION
Resolves #42.

## Verification: not exposed

The advisory in #42 flags malicious `@asyncapi` versions published 14 July 2026. This repo reaches `@asyncapi/specs` transitively via `insomnium` → `@stoplight/spectral-rulesets`. Checked and clean:

| Check | Result |
|---|---|
| Lockfile pin for `@asyncapi/specs` | `6.11.1` + matching integrity hash — the safe version |
| Malicious versions (`6.11.2`, `6.11.2-alpha.1`) in lockfile | none |
| `@asyncapi/generator*` packages | not in the dependency graph at all |
| Installed `node_modules/@asyncapi/specs` | `6.11.1` |
| `sync.js` backdoor artifact under `@asyncapi/*` | none |

The malicious versions have also been unpublished from the registry — `npm view @asyncapi/specs versions` stops at `6.11.1`, and `latest` is `6.11.1`. **No credential rotation is warranted.**

## Change

Adds a defensive pin to the existing security-overrides block in `package.json`:

```json
"@asyncapi/specs": "6.11.1"
```

Exact rather than `^6.11.1`, so a republished `6.11.2` cannot slip back in through the transitive `^6.8.0` range. Consistent with how the block already handles `minimatch`, `xml2js`, `lodash`, etc.

## Note on the lockfile diff

Regenerating the lockfile (`npm install --package-lock-only --ignore-scripts`) also picked up unrelated drift left behind by the version-bump commit 99d9039: four workspace `version` fields moving `0.3.0-rc.5` → `0.3.0-rc.7` to match their `package.json`s. That is the only other change.

The `@asyncapi/specs` lockfile entry itself is byte-identical before and after — which is the clearest confirmation the override is a no-op today and purely forward-looking.
