### PR TITLE
Fix concurrency group so duplicate push/PR runs actually cancel

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,13 +1,13 @@
 name: CodeQL
 
 # Static analysis for JS/TS. Findings land in the repo's "Code scanning" tab.
-# Runs on every push (any branch), every PR, and weekly on a cron so newly-
-# published query updates pick up issues even when nothing's been pushed.
+# Runs on pushes to main, every PR, and weekly on a cron so newly-published
+# query updates pick up issues even when nothing has been pushed.
 
 on:
   push:
     branches:
-      - "**"
+      - main
   pull_request:
     types:
       - opened
@@ -16,7 +16,8 @@ on:
     # Weekly, Monday 06:00 UTC. Lets weekly query-pack updates surface issues.
     - cron: "0 6 * * 1"
 
-# Cancel duplicate runs (push + PR on the same branch) like the Test workflow.
+# `push` is limited to main so PR branches only run via `pull_request`, like
+# the Test workflow. Concurrency cancels runs superseded by a newer commit.
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,14 +5,15 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - "**"
+      - main
   pull_request:
     types:
       - opened
       - synchronize
 
-# Pushes to a PR branch trigger both `push` and `pull_request` events.
-# Cancel the older duplicate run so we don't burn double CI minutes.
+# `push` is limited to main: PR branches are covered by the `pull_request`
+# event, so they run once instead of twice. Concurrency then only has to
+# cancel runs superseded by a newer commit on the same branch.
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Both test.yml and codeql.yml trigger on push (branches: "**") and pull_request, so every push to a PR branch starts two runs. The concurrency key was meant to cancel the older duplicate, but it never matched between the two events:

  push          head_ref = ''        ref_name = <branch>
  pull_request  head_ref = <branch>  ref_name = <n>/merge

so `head_ref || ref` resolved to `refs/heads/<branch>` for push and `<branch>` for pull_request -- two different groups, nothing cancelled. Using `ref_name` as the fallback makes both events resolve to the plain branch name and land in the same group.

Every open PR currently runs the full Lint/Test/Smoke/Package matrix plus CodeQL twice, which doubles CI minutes and gives a flaky install two independent chances to redden a PR.

<!--
Please open an [Issue](https://github.com/ArchGPT/insomnium/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
