### PR TITLE
Version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25756,7 +25756,7 @@
     },
     "packages/insomnia": {
       "name": "insomnium",
-      "version": "0.3.0-rc.8",
+      "version": "0.3.0-rc.9",
       "license": "MIT",
       "dependencies": {
         "@apideck/better-ajv-errors": "^0.3.6",
@@ -25917,7 +25917,7 @@
       }
     },
     "packages/insomnia-send-request": {
-      "version": "0.3.0-rc.8",
+      "version": "0.3.0-rc.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@getinsomnia/node-libcurl": "3.2.2",
@@ -25959,7 +25959,7 @@
       }
     },
     "packages/insomnia-smoke-test": {
-      "version": "0.3.0-rc.8",
+      "version": "0.3.0-rc.9",
       "license": "Apache-2.0",
       "dependencies": {
         "depd": "^1.1.2",
@@ -26035,7 +26035,7 @@
       }
     },
     "packages/insomnia-testing": {
-      "version": "0.3.0-rc.8",
+      "version": "0.3.0-rc.9",
       "license": "Apache-2.0"
     },
     "packages/insomnia/node_modules/@apideck/better-ajv-errors": {
@@ -26162,7 +26162,7 @@
       }
     },
     "packages/insomnium-cli": {
-      "version": "1.0.1-rc.0",
+      "version": "1.0.1-rc.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0"
@@ -26178,7 +26178,7 @@
       }
     },
     "packages/insomnium-mcp": {
-      "version": "1.0.1-rc.0",
+      "version": "1.0.1-rc.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0"

--- a/packages/insomnia-send-request/package.json
+++ b/packages/insomnia-send-request/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "insomnia-send-request",
   "license": "Apache-2.0",
-  "version": "0.3.0-rc.8",
+  "version": "0.3.0-rc.9",
   "author": "Archy <archy@archgpt.dev>",
   "main": "dist/index.js",
   "types": "dist/send-request/index.d.ts",

--- a/packages/insomnia-smoke-test/package.json
+++ b/packages/insomnia-smoke-test/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/ArchGPT/insomnium/issues"
   },
-  "version": "0.3.0-rc.8",
+  "version": "0.3.0-rc.9",
   "scripts": {
     "test:dev": "xvfb-maybe cross-env BUNDLE=dev playwright test",
     "test:build": "xvfb-maybe cross-env BUNDLE=build playwright test",

--- a/packages/insomnia-testing/package.json
+++ b/packages/insomnia-testing/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "insomnia-testing",
   "license": "Apache-2.0",
-  "version": "0.3.0-rc.8",
+  "version": "0.3.0-rc.9",
   "author": "Archy <archy@archgpt.dev>",
   "repository": {
     "type": "git",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnium",
-  "version": "0.3.0-rc.8",
+  "version": "0.3.0-rc.9",
   "productName": "Insomnium",
   "private": true,
   "description": "The Collaborative API Design Tool",

--- a/packages/insomnium-cli/package.json
+++ b/packages/insomnium-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnium-cli",
-  "version": "1.0.1-rc.0",
+  "version": "1.0.1-rc.1",
   "description": "Command-line interface for driving a running Insomnium API client over its loopback MCP server — list, inspect, and run saved requests from the shell or an LLM agent.",
   "license": "MIT",
   "author": "Archy <archy@archgpt.dev>",

--- a/packages/insomnium-mcp/package.json
+++ b/packages/insomnium-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnium-mcp",
-  "version": "1.0.1-rc.0",
+  "version": "1.0.1-rc.1",
   "description": "MCP stdio launcher that bridges AI clients to a running Insomnium API client — list, inspect, and run your saved REST/GraphQL/gRPC requests over the Model Context Protocol.",
   "license": "MIT",
   "author": "Archy <archy@archgpt.dev>",


### PR DESCRIPTION
Bumps the workspaces for the 0.3.0-rc.9 release.

- `insomnia`, `insomnia-send-request`, `insomnia-smoke-test`, `insomnia-testing`: 0.3.0-rc.8 -> 0.3.0-rc.9
- `insomnium-cli`, `insomnium-mcp`: 1.0.1-rc.0 -> 1.0.1-rc.1

Generated with `npm --workspaces version prerelease --preid rc`, producing the same 7-file diff shape as the rc.7 -> rc.8 bump in #56. Lockfile changes are version lines only.