### PR TITLE
Derive the cookie jar ID without hashing

### DIFF
--- a/packages/insomnia/src/models/cookie-jar.ts
+++ b/packages/insomnia/src/models/cookie-jar.ts
@@ -1,5 +1,3 @@
-import crypto from 'crypto';
-
 import { database as db } from '../common/database';
 import type { BaseModel } from './index';
 
@@ -73,8 +71,9 @@ export async function getOrCreateForParentId(parentId: string) {
     return create({
       parentId,
       // Deterministic ID. It helps reduce sync complexity since we won't have to
-      // de-duplicate environments.
-      _id: `${prefix}_${crypto.createHash('sha1').update(parentId).digest('hex')}`,
+      // de-duplicate environments. parentId is already unique, so no hash is
+      // needed -- this matches how models/environment.ts derives its base env ID.
+      _id: `${prefix}_${parentId}`,
     });
   } else {
     return cookieJars[0];


### PR DESCRIPTION
Resolves both open **high** code scanning alerts — [806](https://github.com/yokomohoyo/insomnium/security/code-scanning/806) (`js/insufficient-password-hash`) and [808](https://github.com/yokomohoyo/insomnium/security/code-scanning/808) (`js/weak-cryptographic-algorithm`). They sit on the same line of `packages/insomnia/src/models/cookie-jar.ts`.

## What was flagged

```js
_id: `${prefix}_${crypto.createHash('sha1').update(parentId).digest('hex')}`,
```

## The alerts are false positives

CodeQL's taint path claims a credential reaches the hash — it names `_oAuth2Token`, `clientCertificate` and `caCertificate`. None of those appear in this file. Tracing every caller of `getOrCreateForParentId`, all of them pass a workspace `_id`:

- `ui/routes/workspace.tsx`, `ui/routes/actions.tsx`, `ui/components/request-url-bar.tsx`, `ui/components/websockets/*`, `templating/base-extension.ts`, `common/render.ts` — all `workspace._id` / `workspaceId`

It's cross-file taint bleeding through the `models` barrel. The SHA-1 was deriving a document ID, never hashing a secret.

## Why remove the hash rather than switch to SHA-256

SHA-256 would have closed 808 but **not** 806. `js/insufficient-password-hash` fires on any fast general-purpose hash — SHA-256 included — because the rule's whole point is that such hashes are unsuitable for passwords. As long as CodeQL believes a password reaches a `createHash` sink, changing the algorithm doesn't help. Removing the sink does.

And the hash was never needed: `parentId` is already unique. `models/environment.ts` derives its base environment ID exactly this way already —

```js
// Deterministic base env ID (derived from parentId) so sync converges without
// de-duplicating. parentId is already unique, so no hash is needed.
const baseId = `${prefix}_${parentId}`;
```

so this brings the two models in line instead of inventing a third approach.

## Compatibility

Existing cookie jars are **unaffected**. `getOrCreateForParentId` queries by `parentId` first and only falls back to the derived `_id` when it needs to create one, so no existing jar is orphaned.

The determinism exists for sync convergence, so there is one real consequence: an old client and a new client that both create a jar for the same workspace derive different IDs, and sync could see two. That window is identical to the one a SHA-256 swap would have opened — it is inherent to changing the derivation at all, not to this particular choice.

## Verification

- `npm run lint --workspace=packages/insomnia` — 0 errors (19 pre-existing warnings, none in this file).
- `npm run type-check --workspace=packages/insomnia` — clean.
- 14 suites / 266 tests covering `src/models` and the export + HAR paths that exercise cookie jars — all passing.

## Noticed in passing, not addressed

`models/environment.ts` wraps its `create` in a try/catch for a concurrent-insert race on the deterministic `_id`; `cookie-jar.ts` has no such guard. That race predates this change and is unchanged by it, so it is left alone here.