### PR TITLE
Drop dead code flagged by code scanning in database.ts

### DIFF
--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -11,7 +11,6 @@ import type { BaseModel } from '../models/index';
 import * as models from '../models/index';
 import type { Workspace } from '../models/workspace';
 import { generateId } from './misc';
-import { dummyStartingWorkspace, importToWorkspaceFromJSON } from './import';
 import type { SqliteStore, StoreQuery } from './sqlite-store';
 
 export interface Query {
@@ -532,7 +531,7 @@ export const database = {
       return [];
     }
 
-    let docsToReturn: T[] = doc ? [doc] : [];
+    let docsToReturn: T[] = [doc];
     // Guard against parentId cycles (e.g. a request reparented onto itself or a
     // descendant via update_request) - without this the walk recurses forever.
     const seen = new Set<string>([doc._id]);


### PR DESCRIPTION
Clears the last two open code scanning alerts that have a real fix — [809](https://github.com/yokomohoyo/insomnium/security/code-scanning/809) and [814](https://github.com/yokomohoyo/insomnium/security/code-scanning/814). Both are genuine dead code, not false positives.

## `js/unused-local-variable` (809) — `database.ts:14`

```js
import { dummyStartingWorkspace, importToWorkspaceFromJSON } from './import';
```

Neither binding is referenced anywhere in the file — each name appears exactly once, on this line.

It was also a **dependency cycle**: `common/import.ts` imports `./database` at its line 17, so `database.ts → import.ts → database.ts`. Removing the dead import breaks the cycle, which is a real initialization-order hazard gone rather than just a lint nit. Eight other modules import `common/import`, so nothing depended on `database.ts` being the one to pull it in.

## `js/trivial-conditional` (814) — `database.ts:535`

```js
if (!doc) {
  return [];
}

let docsToReturn: T[] = doc ? [doc] : [];   // else branch unreachable
```

`withAncestors` returns early on `!doc` four lines above, so the ternary always takes the first branch. Simplified to `[doc]`. The very next line already relies on this — `new Set<string>([doc._id])` would have thrown on a null `doc`.

## Verification

- `npm test --workspace=packages/insomnia` — 90 suites, 1181 tests, all passing.
- `npm run lint --workspace=packages/insomnia` — 0 errors (19 pre-existing warnings, none here).
- `npm run type-check --workspaces` — clean across `insomnia`, `insomnium-mcp`, `insomnium-cli`.

The full suite matters more than usual here, since removing a circular import can shift module initialization order.

## Remaining alerts after this

Only the two `js/file-access-to-http` mediums in `network/gcp-id-token/get-token.ts`, both false positives:

- **804** (line 293) — the request host is the hardcoded constant `IAMCREDENTIALS_HOST`. The only file-derived value is `targetSaEmail`, `encodeURIComponent`-escaped into a path segment, so the destination cannot be influenced at all.
- **803** (line 253) — the host can come from `sa.token_uri` in the service account key, but `assertSafeTokenUri` runs immediately before the `fetch` and enforces https plus a hostname under `googleapis.com` / `google.com`. CodeQL does not model that guard as a sanitizer.

Sending service account key material to Google's token endpoint is what SA authentication *is*, so no code change removes this dataflow. Recommend dismissing both as false positives.