### PR TITLE
Version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25641,7 +25641,7 @@
     },
     "packages/insomnia": {
       "name": "insomnium",
-      "version": "0.3.0-rc.9",
+      "version": "0.3.0-rc.10",
       "license": "MIT",
       "dependencies": {
         "@apideck/better-ajv-errors": "^0.3.6",
@@ -25802,7 +25802,7 @@
       }
     },
     "packages/insomnia-send-request": {
-      "version": "0.3.0-rc.9",
+      "version": "0.3.0-rc.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@getinsomnia/node-libcurl": "3.2.2",
@@ -25844,7 +25844,7 @@
       }
     },
     "packages/insomnia-smoke-test": {
-      "version": "0.3.0-rc.9",
+      "version": "0.3.0-rc.10",
       "license": "Apache-2.0",
       "dependencies": {
         "depd": "^1.1.2",
@@ -25920,7 +25920,7 @@
       }
     },
     "packages/insomnia-testing": {
-      "version": "0.3.0-rc.9",
+      "version": "0.3.0-rc.10",
       "license": "Apache-2.0"
     },
     "packages/insomnia/node_modules/@apideck/better-ajv-errors": {
@@ -26019,7 +26019,7 @@
       }
     },
     "packages/insomnium-cli": {
-      "version": "1.0.1-rc.1",
+      "version": "1.0.1-rc.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0"
@@ -26035,7 +26035,7 @@
       }
     },
     "packages/insomnium-mcp": {
-      "version": "1.0.1-rc.1",
+      "version": "1.0.1-rc.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0"

--- a/packages/insomnia-send-request/package.json
+++ b/packages/insomnia-send-request/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "insomnia-send-request",
   "license": "Apache-2.0",
-  "version": "0.3.0-rc.9",
+  "version": "0.3.0-rc.10",
   "author": "Archy <archy@archgpt.dev>",
   "main": "dist/index.js",
   "types": "dist/send-request/index.d.ts",

--- a/packages/insomnia-smoke-test/package.json
+++ b/packages/insomnia-smoke-test/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/ArchGPT/insomnium/issues"
   },
-  "version": "0.3.0-rc.9",
+  "version": "0.3.0-rc.10",
   "scripts": {
     "test:dev": "xvfb-maybe cross-env BUNDLE=dev playwright test",
     "test:build": "xvfb-maybe cross-env BUNDLE=build playwright test",

--- a/packages/insomnia-testing/package.json
+++ b/packages/insomnia-testing/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "insomnia-testing",
   "license": "Apache-2.0",
-  "version": "0.3.0-rc.9",
+  "version": "0.3.0-rc.10",
   "author": "Archy <archy@archgpt.dev>",
   "repository": {
     "type": "git",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnium",
-  "version": "0.3.0-rc.9",
+  "version": "0.3.0-rc.10",
   "productName": "Insomnium",
   "private": true,
   "description": "The Collaborative API Design Tool",

--- a/packages/insomnium-cli/package.json
+++ b/packages/insomnium-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnium-cli",
-  "version": "1.0.1-rc.1",
+  "version": "1.0.1-rc.2",
   "description": "Command-line interface for driving a running Insomnium API client over its loopback MCP server — list, inspect, and run saved requests from the shell or an LLM agent.",
   "license": "MIT",
   "author": "Archy <archy@archgpt.dev>",

--- a/packages/insomnium-mcp/package.json
+++ b/packages/insomnium-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnium-mcp",
-  "version": "1.0.1-rc.1",
+  "version": "1.0.1-rc.2",
   "description": "MCP stdio launcher that bridges AI clients to a running Insomnium API client — list, inspect, and run your saved REST/GraphQL/gRPC requests over the Model Context Protocol.",
   "license": "MIT",
   "author": "Archy <archy@archgpt.dev>",


### PR DESCRIPTION
0.3.0-rc.9 → **0.3.0-rc.10**, cutting a security release.

`npm --workspaces version prerelease --preid rc` — 7 files, version lines only. The four `insomnia*` workspaces go to 0.3.0-rc.10, `insomnium-cli` and `insomnium-mcp` to 1.0.1-rc.2, root `package.json` stays at 1.0.0.

## What's in this release

Both security tabs go from 24 open Dependabot alerts and 6 code scanning alerts to **zero open on each**.

### Dependabot — #78, #79, #80

| Package | Was | Now | Severity |
| --- | --- | --- | --- |
| `xmldom` | 0.1.31 | aliased to `@xmldom/xmldom` 0.8.15 | 1 critical, 5 high, 1 med |
| `js-yaml` | 3.14.2 / 4.2.0–4.3.1 | 3.15.2 / 4.3.2 | 4 high, 1 med |
| `js-cookie` | 2.2.1 | 3.0.8 | 1 high |
| `serialize-javascript` | 6.0.2 | 7.1.1 | 1 high |
| `react-router` / `react-router-dom` | 6.30.4 | 7.18.3 | 3 med |
| `protobufjs` | 7.6.2 | 7.6.6 | 2 med |
| `@hono/node-server` | 1.19.14 | 1.19.17 | 1 med |
| `xml2js` | 0.4.23 | 0.5.0 | 1 med |

`lodash.set` (high) was dismissed as not reachable — no patched release exists, and both call sites in `grpc-reflection-js` pass hardcoded paths, so a hostile reflection response controls values but never the key path.

### Code scanning — #81, #82

- `js/insufficient-password-hash` + `js/weak-cryptographic-algorithm` (both high) — the cookie jar ID no longer derives from a SHA-1 hash. CodeQL's taint path was wrong, but the hash was pointless anyway since `parentId` is already unique.
- `js/unused-local-variable` + `js/trivial-conditional` — dead code in `common/database.ts`. The unused import was also a `database.ts → import.ts → database.ts` cycle.
- Two `js/file-access-to-http` mediums dismissed as false positives; sending SA key material to Google's token endpoint is what service-account auth is.

## Notable behaviour changes

**react-router 6 → 7** is a major upgrade. Every imported symbol carries over unchanged across all 104 import sites, and there is no `json()`/`defer()` usage, so no source changes were needed — but it is the largest functional change here and worth watching.

**Cookie jar IDs** are now `jar_<parentId>` rather than `jar_<sha1(parentId)>`. Existing jars are unaffected (lookup goes through the `parentId` query), but an rc.9 and an rc.10 client that each create a jar for the same workspace derive different IDs, so sync could see two.

## Verification

Every PR was green on all six checks, including Package and Smoke. Full suite on this branch: 90 suites, 1181 tests.