### PR TITLE
Trigger the APT repo build from workflow_run, not release

### DIFF
--- a/.github/workflows/apt-repo.yml
+++ b/.github/workflows/apt-repo.yml
@@ -12,9 +12,15 @@ name: APT Repository
 #
 # See docs/apt-repository.md for one-time setup.
 
+# Triggered by workflow_run rather than `release: published`, for two reasons:
+# a workflow_run event runs in the DEFAULT BRANCH's context, which is what the
+# github-pages environment's protection rule requires (a release event runs in
+# the tag's context and is rejected outright); and it starts only once Release
+# On Publish has finished uploading the .deb, instead of racing it.
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release On Publish"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       keep:
@@ -38,6 +44,8 @@ permissions:
 
 jobs:
   publish:
+    # Skip when the triggering build failed; a manual dispatch always runs.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/docs/apt-repository.md
+++ b/docs/apt-repository.md
@@ -90,7 +90,9 @@ domain, update `APT_SOURCE_URL` there to match.
 
 ## How it runs
 
-The workflow triggers on `release: published`, after release assets exist. It:
+The workflow triggers on `workflow_run` once **Release On Publish** completes
+successfully, so the `.deb` assets are already uploaded by the time it starts.
+It:
 
 1. Downloads `.deb` assets from the most recent releases (default 5 — see below)
 2. Builds `dists/stable/main/binary-amd64/Packages` with `apt-ftparchive`
@@ -101,6 +103,13 @@ The workflow triggers on `release: published`, after release assets exist. It:
 
 It can also be run manually via **workflow_dispatch**, which takes a `keep`
 input if you need a different number of retained releases.
+
+> It deliberately does *not* trigger on `release: published`. That event runs in
+> the tag's context, and the `github-pages` environment only permits deployments
+> from `main`, so the job was rejected before any step ran:
+> `Tag "<version>" is not allowed to deploy to github-pages due to environment
+> protection rules.` A `workflow_run` event runs in the default branch's context
+> instead, which satisfies the rule.
 
 ### Two size limits, and why the deployment method matters
 


### PR DESCRIPTION
The `release: published` trigger on `apt-repo.yml` has **never worked**. It failed again on 0.3.0-rc.10 ([run 33535157604](https://github.com/yokomohoyo/insomnium/actions/runs/33535157604)) the same way it always does — rejected in ~1 second with zero steps executed:

> Tag "0.3.0-rc.10" is not allowed to deploy to github-pages due to environment protection rules.

## Why it can't work

A `release` event runs in the **tag's** context. The `github-pages` environment's protection rule only permits deployments from `main`. So the job is rejected before any step runs — this is not a flake or a transient, it is structural, and no amount of retrying the release trigger will help.

The workaround so far has been a manual `gh workflow run apt-repo.yml --ref main` after each release. That works, but it leaves a red X on every release and depends on someone remembering.

## The fix

`workflow_run` events run in the **default branch's** context, which satisfies the environment rule.

```yaml
on:
  workflow_run:
    workflows: ["Release On Publish"]
    types: [completed]
  workflow_dispatch:
    ...
```

`homebrew.yml` already triggers exactly this way, so this brings the two release-followers in line rather than introducing a new pattern.

## It also fixes a second, quieter bug

The `release` trigger fired *concurrently with* the artifact build, so `apt-repo` would go looking for a `.deb` that Release On Publish had not finished uploading. Even in a world where the environment rule allowed it, the run would have been racy. `workflow_run` starts only after that build completes, so the assets are guaranteed present.

That also makes the docs' claim accurate for the first time — `docs/apt-repository.md` said the workflow triggers "after release assets exist", which was never true.

## Guard

```yaml
if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
```

so a failed build does not publish a repo index, while manual dispatch still always runs. `keep` still defaults to 5 — under `workflow_run` there are no `inputs`, so `github.event.inputs.keep || '5'` falls through correctly.

## Verification

The YAML parses and resolves to the intended triggers and guard. Beyond that this can only really be verified by the next release: **on the next one, `apt-repo` should run and succeed on its own, with no manual dispatch.** If it does not, the manual `gh workflow run apt-repo.yml --ref main` remains available and unchanged.

Nothing about the build/sign/deploy steps changed — only when the workflow starts.