### PR TITLE
Version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25641,7 +25641,7 @@
     },
     "packages/insomnia": {
       "name": "insomnium",
-      "version": "0.3.0-rc.10",
+      "version": "0.3.0-rc.11",
       "license": "MIT",
       "dependencies": {
         "@apideck/better-ajv-errors": "^0.3.6",
@@ -25802,7 +25802,7 @@
       }
     },
     "packages/insomnia-send-request": {
-      "version": "0.3.0-rc.10",
+      "version": "0.3.0-rc.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@getinsomnia/node-libcurl": "3.2.2",
@@ -25844,7 +25844,7 @@
       }
     },
     "packages/insomnia-smoke-test": {
-      "version": "0.3.0-rc.10",
+      "version": "0.3.0-rc.11",
       "license": "Apache-2.0",
       "dependencies": {
         "depd": "^1.1.2",
@@ -25920,7 +25920,7 @@
       }
     },
     "packages/insomnia-testing": {
-      "version": "0.3.0-rc.10",
+      "version": "0.3.0-rc.11",
       "license": "Apache-2.0"
     },
     "packages/insomnia/node_modules/@apideck/better-ajv-errors": {
@@ -26019,7 +26019,7 @@
       }
     },
     "packages/insomnium-cli": {
-      "version": "1.0.1-rc.2",
+      "version": "1.0.1-rc.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0"
@@ -26035,7 +26035,7 @@
       }
     },
     "packages/insomnium-mcp": {
-      "version": "1.0.1-rc.2",
+      "version": "1.0.1-rc.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0"

--- a/packages/insomnia-send-request/package.json
+++ b/packages/insomnia-send-request/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "insomnia-send-request",
   "license": "Apache-2.0",
-  "version": "0.3.0-rc.10",
+  "version": "0.3.0-rc.11",
   "author": "Archy <archy@archgpt.dev>",
   "main": "dist/index.js",
   "types": "dist/send-request/index.d.ts",

--- a/packages/insomnia-smoke-test/package.json
+++ b/packages/insomnia-smoke-test/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/ArchGPT/insomnium/issues"
   },
-  "version": "0.3.0-rc.10",
+  "version": "0.3.0-rc.11",
   "scripts": {
     "test:dev": "xvfb-maybe cross-env BUNDLE=dev playwright test",
     "test:build": "xvfb-maybe cross-env BUNDLE=build playwright test",

--- a/packages/insomnia-testing/package.json
+++ b/packages/insomnia-testing/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "insomnia-testing",
   "license": "Apache-2.0",
-  "version": "0.3.0-rc.10",
+  "version": "0.3.0-rc.11",
   "author": "Archy <archy@archgpt.dev>",
   "repository": {
     "type": "git",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnium",
-  "version": "0.3.0-rc.10",
+  "version": "0.3.0-rc.11",
   "productName": "Insomnium",
   "private": true,
   "description": "The Collaborative API Design Tool",

--- a/packages/insomnium-cli/package.json
+++ b/packages/insomnium-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnium-cli",
-  "version": "1.0.1-rc.2",
+  "version": "1.0.1-rc.3",
   "description": "Command-line interface for driving a running Insomnium API client over its loopback MCP server — list, inspect, and run saved requests from the shell or an LLM agent.",
   "license": "MIT",
   "author": "Archy <archy@archgpt.dev>",

--- a/packages/insomnium-mcp/package.json
+++ b/packages/insomnium-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnium-mcp",
-  "version": "1.0.1-rc.2",
+  "version": "1.0.1-rc.3",
   "description": "MCP stdio launcher that bridges AI clients to a running Insomnium API client — list, inspect, and run your saved REST/GraphQL/gRPC requests over the Model Context Protocol.",
   "license": "MIT",
   "author": "Archy <archy@archgpt.dev>",


### PR DESCRIPTION
0.3.0-rc.10 → **0.3.0-rc.11**.

`npm --workspaces version prerelease --preid rc --no-git-tag-version` — 7 files, version lines only. The four `insomnia*` workspaces go to 0.3.0-rc.11, `insomnium-cli` and `insomnium-mcp` to 1.0.1-rc.3, root `package.json` stays at 1.0.0.

## What's in it

Only two changes since rc.10, neither user-facing:

- #84 — browserslist 4.28.2 → 4.28.8 (Dependabot)
- #85 — `apt-repo.yml` now triggers on `workflow_run` instead of `release: published`

## Why cut it

Primarily to exercise #85. The `release: published` trigger had failed on every release with `Tag "<version>" is not allowed to deploy to github-pages due to environment protection rules`, and the fix can only be verified by an actual release.

**The thing to watch:** after `Release On Publish` finishes, `APT Repository` should start on its own and go green — with no `gh workflow run apt-repo.yml --ref main`. That has never happened before; every prior release needed the manual dispatch.

If it still fails, the manual dispatch remains available and unchanged.